### PR TITLE
Remove deprecated React.__spread

### DIFF
--- a/lib/ToolbarRegion.js
+++ b/lib/ToolbarRegion.js
@@ -68,7 +68,7 @@ module.exports = React.createClass({
 	render: function(){
 		var props = this.prepareProps(this.props)
 
-		return React.createElement("div", React.__spread({},  props))
+		return React.createElement("div", props)
 	},
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,7 @@ var Toolbar = React.createClass({
 
 		// this.prepareContent(props)
 
-		return React.createElement("div", React.__spread({},  props))
+		return React.createElement("div", props)
 	},
 
 	prepareContent: function(props){


### PR DESCRIPTION
React.__spread is deprecated in [React v15](https://facebook.github.io/react/blog/2016/04/08/react-v15.0.1.html)

